### PR TITLE
ci: ignore specified paths

### DIFF
--- a/.github/workflows/execute_tests.yml
+++ b/.github/workflows/execute_tests.yml
@@ -3,6 +3,13 @@ name: Run Test
 on:
   pull_request:
     branches: [ "main" ]
+    paths-ignore: 
+      - LICENSE
+      - README.md
+      - .github/*.md
+      - .github/CODEOWNERS
+      - .env.example
+      - .gitignore
 
 jobs:
   build:


### PR DESCRIPTION
## Describe the Change

Ignore specified paths(files) to only execute the CI to run tests, when is necessary.

## Past and Current Behavior

Before, all changes triggered the CI to run tests! Now, the CI to run tests only execute when the docker or javascript files is changed!

## Checklist

- [x] - Feature 🚀 
- [ ] - Fix 🧰
- [ ] - Documentation 📖 
- [x] - Improvement 🌟
- [ ] - Hot Fix 🔥
- [ ] - Security 🔒
- [x] - Pass in All Tests 🧪
- [ ] - Create new warnings ⚠️
- [ ] - Create new comments 💬
